### PR TITLE
Update autosize.directive.ts

### DIFF
--- a/src/autosize.directive.ts
+++ b/src/autosize.directive.ts
@@ -11,7 +11,7 @@ export class Autosize {
   }
   constructor(public element: ElementRef){
   }
-  ngOnInit(): void{
+  ngAfterContentChecked(): void{
     this.adjust();
   }
   adjust(): void{


### PR DESCRIPTION
Changed ngOnitit to ngAfterContentChecked to prevent textarea from collapsing when data is not binded yet. This change was proposed by **Dyljyn** here [https://github.com/stevepapa/angular2-autosize/issues/7](url)
